### PR TITLE
add espressif prefix to mdns component name

### DIFF
--- a/components/snapclient/__init__.py
+++ b/components/snapclient/__init__.py
@@ -57,7 +57,7 @@ async def to_code(config):
         repo="https://github.com/espressif/esp-dsp.git",
     )
     add_idf_component(
-        name="mdns",
+        name="espressif/mdns",
         repo="https://github.com/espressif/esp-protocols.git",
         path="components/mdns",
     )


### PR DESCRIPTION
In order to get your snapcast component compiled, I had to add the espressif prefix to the mdns componen name.

Thank you very much for creating this component!